### PR TITLE
Fix Malwarebytes Incident Response version detection

### DIFF
--- a/MalwarebytesIncidentResponse/MalwarebytesIncidentResponse.download.recipe
+++ b/MalwarebytesIncidentResponse/MalwarebytesIncidentResponse.download.recipe
@@ -14,11 +14,11 @@ You must provide a Client ID and Secret along with the Client Account to downloa
 		<key>NAME</key>
 		<string>malwarebytes</string>
 		<key>CLIENT_ID</key>
-		<string>mwb-cloud-E4HGk8IxBeetHvg8sVL2dVBwomCI3eDn</string>
+		<string>%MWB_CLIENT_ID%</string>
 		<key>CLIENT_SECRET</key>
-		<string>7vrqvSys4Lgd5t7ZDMG3sE70Yrt5z6L3AnTP52tcCNkvbqW8CAY2HmoHLPtPfMci</string>
+		<string>%MWB_CLIENT_SECRET%</string>
 		<key>ACCOUNT_ID</key>
-		<string>JrhGzFZs-3BaN-lMnX-YW3c-493141650896</string>
+		<string>%MWB_ACCOUNT_ID%</string>
 	</dict>
 	<key>Process</key>
 	<array>

--- a/MalwarebytesIncidentResponse/MalwarebytesIncidentResponse.download.recipe
+++ b/MalwarebytesIncidentResponse/MalwarebytesIncidentResponse.download.recipe
@@ -43,7 +43,7 @@ You must provide a Client ID and Secret along with the Client Account to downloa
 				<key>url</key>
 				<string>%download_url%</string>
 				<key>filename</key>
-				<string>Setup.MBEndpointAgent-%version%.pkg</string>
+				<string>Setup.MBEndpointAgent.pkg</string>
 			</dict>
 		</dict>
 		<dict>
@@ -58,6 +58,55 @@ You must provide a Client ID and Secret along with the Client Account to downloa
 					<string>Developer ID Installer: Malwarebytes Corporation (GVZRY6KDKR)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+			<key>Arguments</key>
+			<dict>
+				<key>flat_pkg_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpacked_pkg</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpacked_pkg/MBBRNebulaAgentInstaller.pkg/Payload</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/extracted_payload</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%RECIPE_CACHE_DIR%/extracted_payload/Library/Application Support/Malwarebytes/Malwarebytes Endpoint Agent/EndpointAgentDaemon.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleVersion</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/unpacked_pkg</string>
+					<string>%RECIPE_CACHE_DIR%/extracted_payload</string>
 				</array>
 			</dict>
 		</dict>

--- a/MalwarebytesIncidentResponse/MalwarebytesIncidentResponse.munki.recipe
+++ b/MalwarebytesIncidentResponse/MalwarebytesIncidentResponse.munki.recipe
@@ -12,12 +12,18 @@ You must also specify an ACCOUNT TOKEN in order to enroll malwarebytes correctil
     <string>com.github.weswhet.munki.malwarebytesincidentresponse</string>
     <key>Input</key>
     <dict>
+        <key>ACCOUNT_ID</key>
+        <string>%MWB_ACCOUNT_ID%</string>
+        <key>ACCOUNT_TOKEN</key>
+        <string>%MWB_ACCOUNT_TOKEN%</string>
+        <key>CLIENT_ID</key>
+        <string>%MWB_CLIENT_ID%</string>
+        <key>CLIENT_SECRET</key>
+        <string>%MWB_CLIENT_SECRET%</string>
         <key>MUNKI_CATEGORY</key>
         <string>Security</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/malwarebytes</string>
-        <key>ACCOUNT_TOKEN</key>
-        <string>JrhGzFZs-3BaN-lMnX-YW3c-493141650896</string>
         <key>NAME</key>
         <string>malwarebytes</string>
         <key>pkginfo</key>

--- a/MalwarebytesIncidentResponse/MalwarebytesIncidentResponse.py
+++ b/MalwarebytesIncidentResponse/MalwarebytesIncidentResponse.py
@@ -88,10 +88,9 @@ class MalwarebytesIncidentResponse(URLGetter):
         response = installers.json()
         self.output(f"Installer API Response: {response}", verbose_level=3)
 
-        # We only want the mac_os url and version
+        # We only want the mac_os url
         try:
             dl_url = response["mac_os"]["url"]
-            pkg_version = response["mac_os"]["version"]
         except KeyError:
             self.output(f"Installer API Response: {response}", verbose_level=1)
             raise ProcessorError(
@@ -100,9 +99,6 @@ class MalwarebytesIncidentResponse(URLGetter):
 
         self.env["download_url"] = dl_url
         self.output(f"Download URL:  {dl_url}", verbose_level=1)
-
-        self.env["version"] = pkg_version
-        self.output(f"Malwarebytes Version: {pkg_version}", verbose_level=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The Malwarebytes API unfortunately seems to be returning empty version and checksum strings when trying to access the [/nebula/v1/installers](https://api.malwarebytes.com/nebula/v1/docs#tag/Installers) endpoint:

```json
{
  "win_full": {
    "url": "deprecated",
    "version": "",
    "link": "deprecated",
    "md5": "",
    "sha256": ""
  },
  "win_web": {
    "url": "deprecated",
    "version": "",
    "link": "deprecated",
    "md5": "",
    "sha256": ""
  },
  "mac_os": {
    "url": "REDACTED_URL",
    "version": "",
    "link": "REDACTED_URL",
    "md5": "",
    "sha256": ""
  },
  "win_msi": {
    "url": "REDACTED_URL",
    "version": "",
    "link": "REDACTED_URL",
    "md5": "",
    "sha256": ""
  },
  "x64_msi": {
    "url": "REDACTED_URL",
    "version": "",
    "link": "REDACTED_URL",
    "md5": "",
    "sha256": ""
  }
}
```

Proposing we fix this by grabbing the version from the `CFBundleVersion` string within `Malwarebytes Endpoint Agent.app/Contents/Info.plist`.

This should fix `MalwarebytesIncidentResponse.munki.recipe`'s dependency on the `%version%` variable 👍

**Download recipe output:**

```shell
autopkg run MalwarebytesIncidentResponse/MalwarebytesIncidentResponse.download.recipe -v 
Processing MalwarebytesIncidentResponse/MalwarebytesIncidentResponse.download.recipe...
MalwarebytesIncidentResponse
MalwarebytesIncidentResponse: Download URL:  REDACTED_URL
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 16 Oct 2023 19:07:58 GMT
URLDownloader: Storing new ETag header: "2545efa648f999845d1f7ff60c08d940-2"
URLDownloader: Downloaded /Users/nindi/Library/AutoPkg/Cache/com.github.weswhet.download.malwarebytesnebula/downloads/Setup.MBEndpointAgent.pkg
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Setup.MBEndpointAgent.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2023-08-21 16:09:26 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Malwarebytes Corporation (GVZRY6KDKR)
CodeSignatureVerifier:        Expires: 2026-03-17 16:48:32 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            60 67 BD 49 57 4D C0 77 AF B2 FA E1 72 6E 01 DE 54 75 D8 38 A9 0F 
CodeSignatureVerifier:            E7 CE 3F C5 DA 54 C5 7D 4D 7A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/nindi/Library/AutoPkg/Cache/com.github.weswhet.download.malwarebytesnebula/downloads/Setup.MBEndpointAgent.pkg to /Users/nindi/Library/AutoPkg/Cache/com.github.weswhet.download.malwarebytesnebula/unpacked_pkg
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/nindi/Library/AutoPkg/Cache/com.github.weswhet.download.malwarebytesnebula/unpacked_pkg/MBBRNebulaAgentInstaller.pkg/Payload to /Users/nindi/Library/AutoPkg/Cache/com.github.weswhet.download.malwarebytesnebula/extracted_payload
Versioner
Versioner: Found version 1.7.0.138 in file /Users/nindi/Library/AutoPkg/Cache/com.github.weswhet.download.malwarebytesnebula/extracted_payload/Library/Application Support/Malwarebytes/Malwarebytes Endpoint Agent/EndpointAgentDaemon.app/Contents/Info.plist
PathDeleter
PathDeleter: Deleted /Users/nindi/Library/AutoPkg/Cache/com.github.weswhet.download.malwarebytesnebula/unpacked_pkg
PathDeleter: Deleted /Users/nindi/Library/AutoPkg/Cache/com.github.weswhet.download.malwarebytesnebula/extracted_payload
EndOfCheckPhase
Receipt written to /Users/nindi/Library/AutoPkg/Cache/com.github.weswhet.download.malwarebytesnebula/receipts/MalwarebytesIncidentResponse.download-receipt-20231017-180535.plist

The following new items were downloaded:
    Download Path                                                                                                          
    -------------                                                                                                          
    /Users/nindi/Library/AutoPkg/Cache/com.github.weswhet.download.malwarebytesnebula/downloads/Setup.MBEndpointAgent.pkg 
```