### PR TITLE
Deprecate Kolide Launcher recipes

### DIFF
--- a/Kolide-Launcher/launcher.download.recipe
+++ b/Kolide-Launcher/launcher.download.recipe
@@ -14,9 +14,18 @@
 		<string>launcher</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Kolide-Launcher recipes in the ccaviness-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates the non-functional Kolide Launcher recipes, and points users to alternative recipes in the ccaviness-recipes repo.
