### PR TITLE
Remove empty `expected_authority_names` array in CodeSignatureVerifier arguments

### DIFF
--- a/MalwarebytesIncidentResponse/MalwarebytesIncidentResponse.munki.recipe
+++ b/MalwarebytesIncidentResponse/MalwarebytesIncidentResponse.munki.recipe
@@ -84,8 +84,6 @@ You must also specify an ACCOUNT TOKEN in order to enroll malwarebytes correctil
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Library/Application Support/Malwarebytes/Malwarebytes Endpoint Agent/UserAgent.app</string>
                 <key>requirement</key>
@@ -99,8 +97,6 @@ You must also specify an ACCOUNT TOKEN in order to enroll malwarebytes correctil
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>expected_authority_names</key>
-                <array/>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Library/Application Support/Malwarebytes/Malwarebytes Endpoint Agent/EndpointAgentDaemon.app</string>
                 <key>requirement</key>


### PR DESCRIPTION
As long as there is a valid `requirements` argument, the `expected_authority_names` argument is not needed for code signature verification. This pull request removes the unnecessary empty `expected_authority_names` array.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.