### PR TITLE
Cleanup temp app bundle and DMG for Tuple recipe

### DIFF
--- a/Tuple/Tuple.munki.recipe
+++ b/Tuple/Tuple.munki.recipe
@@ -58,6 +58,18 @@
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Hi there 👋

The **Tuple** recipe leaves a residual app bundle + DMG around, so this PR attempts to cleanup files that are no longer required.

Should save approximately **60MB** of disk space!